### PR TITLE
NAPPS-1349: add health check to app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'kramdown'
 
 gem 'aws-sdk-sqs', '~> 1.52'
 
+gem 'rails-healthcheck'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,10 +180,10 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.8-arm64-darwin)
+    nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
@@ -237,6 +237,9 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-healthcheck (1.4.0)
+      actionpack
+      railties
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails_12factor (0.0.3)
@@ -366,6 +369,7 @@ DEPENDENCIES
   rack-cache
   rails (~> 6.0.0)
   rails-controller-testing
+  rails-healthcheck
   rails_12factor
   rspec-github
   rspec-rails
@@ -382,4 +386,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.22
+   2.3.26

--- a/config/initializers/healthcheck.rb
+++ b/config/initializers/healthcheck.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Healthcheck.configure do |config|
+  config.success = 200
+  config.error = 503
+  config.verbose = false
+  config.route = '/healthcheck'
+  config.method = :get
+
+  # -- Custom Response --
+  # config.custom = lambda { |controller, checker|
+  #   return controller.render(plain: 'Everything is awesome!') unless checker.errored?
+  #   controller.verbose? ? controller.verbose_error(checker) : controller.head_error
+  # }
+
+  # -- Checks --
+  # config.add_check :database,     -> { ActiveRecord::Base.connection.execute('select 1') }
+  # config.add_check :migrations,   -> { ActiveRecord::Migration.check_pending! }
+  # config.add_check :cache,        -> { Rails.cache.read('some_key') }
+  # config.add_check :environments, -> { Dotenv.require_keys('ENV_NAME', 'ANOTHER_ENV') }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  Healthcheck.routes(self)
   root 'watching#feed'
 
   scope 'api' do


### PR DESCRIPTION
Adds health check to the Klaxon app so that AWS has a path to confirm the app is running. There isn't an easy way to test this, but the aim is to have the minimum configurations required such that the app can be deployed to and ECS cluster. There is [another ticket](https://arcpublishing.atlassian.net/browse/NAPPS-1350) to modify the configurations as needed.

Jira: [NAPPS-1349](https://arcpublishing.atlassian.net/browse/NAPPS-1349)

To test:
- `docker-compose up`
- Confirm you can hit the health check path in your browser: [localhost:3000/healthcheck](localhost:3000/healthcheck)