### PR TITLE
NAPPS-1296: hopefully fixing secret not found error

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -417,7 +417,7 @@ context:
       PORT: 3000
       RACK_ENV: production
       RAILS_ENV: production
-      SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod-secret-key-base:SecretString:secret_key_base}}"
+      SECRET_KEY_BASE: "{{resolve:secretsmanager:klaxon/prod-secret-key-base:SecretString:secret_key_base}}"
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime


### PR DESCRIPTION
Debugging our deploy to an ECS cluster. Error right now seems to indicate a secret in Secrets Manager can't be found. I created one of them manually, so it doesn't follow the same naming convention. I think it should not be prefixed with a `/`. 🤞 hopefully this does it

[NAPPS-1296 ](https://arcpublishing.atlassian.net/browse/NAPPS-1296)

<img width="1092" alt="Screen Shot 2023-01-04 at 9 08 13 AM" src="https://user-images.githubusercontent.com/26312638/210598373-3a6732cc-d8d2-4a58-8bba-c33efcbe6b41.png">


[NAPPS-1296]: https://arcpublishing.atlassian.net/browse/NAPPS-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAPPS-1296]: https://arcpublishing.atlassian.net/browse/NAPPS-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ