### PR TITLE
NAPPS-1296: fix database url

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -412,7 +412,7 @@ context:
 
     environment:
       DEBUG: yes
-      DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/policeshootings/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
+      DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
       ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
       PORT: 3000
       RACK_ENV: production


### PR DESCRIPTION
Fixing a config copy/pasta disasta: `policeshootings` should be `klaxon`. Also confirmed there are no more references to `policeshootings` in the repo 😬 