### PR TITLE
NAPPS-1296: fix 500 error prod

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -6,7 +6,7 @@
 
 ```
 docker-compose up
-open http://localhost:3000
+open http://localhost:3001
 ```
 
 2. Enter 'admin@news.org' in the email window. It should redirect you to a page that says: "Email Sent".

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN bundle install
 # Copy over the rest of the app
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3001
 
+CMD ["bundle", "exec", "rails", "assets:precompile"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,4 @@ COPY . .
 
 EXPOSE 3001
 
-CMD ["bundle", "exec", "rails", "assets:precompile"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -417,6 +417,7 @@ context:
       RACK_ENV: production
       RAILS_ENV: production
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
+      KLAXON_COMPILE_ASSETS: true
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -412,7 +412,7 @@ context:
 
     environment:
       DEBUG: yes
-      DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/policeshootings/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
+      DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
       ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
       PORT: 3000
       RACK_ENV: production

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -414,7 +414,7 @@ context:
       DEBUG: yes
       DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
       ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
-      PORT: 3000
+      PORT: 3001
       RACK_ENV: production
       RAILS_ENV: production
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
@@ -463,7 +463,7 @@ context:
     #     host:
     #       source_path: /tmp
 
-    port: 3000
+    port: 3001
     # protocol: tcp
 
     # port_mapping:

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -411,7 +411,6 @@ context:
     # raw_image_path: customer_path_to_image (Deprecated)
 
     environment:
-      DEBUG: yes
       DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
       ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
       PORT: 3001

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -463,7 +463,7 @@ context:
     #     host:
     #       source_path: /tmp
 
-    port: 3000
+    port: 3001
     # protocol: tcp
 
     # port_mapping:

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -415,7 +415,6 @@ context:
 
 
     environment:
-      DEBUG: yes
       ## TODO: @Katlyn, set up the env vars here
   
     # environment: dictionary

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,7 @@ Rails.application.configure do
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
+  config.serve_static_files = true
 
   # Do not fall back to locating/compiling missing assets.
   config.assets.compile = (ENV.fetch('KLAXON_COMPILE_ASSETS', 'false').to_s.downcase == 'true')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # overriding the default url option
+  Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( search.js )

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,6 +15,6 @@ on_worker_boot do
   end
 end
 
-port = Integer(ENV['PORT'] || 3000)
+port = Integer(ENV['PORT'] || 3001)
 
 bind "tcp://0.0.0.0:#{port}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:14
     env_file:
-      - .env
+      - .env.local
     ports:
       - "5432:5432"
     volumes:
@@ -12,9 +12,9 @@ services:
 
   app:
     ports: 
-      - "3000:3000"
+      - "3001:3001"
     env_file:
-      - .env
+      - .env.local
     build: .
     depends_on:
       - db

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -14,7 +14,7 @@ edit env_local.list (found in the docker_example directory) and use your own val
 
 cd into the docker_example directory in this repo and run the following. You only need to be in this directory because we used a relative path to the env_local.list file.
 
-`docker run -p 8885:3000 --name klaxon_local --env-file ./env_local.list --restart unless-stopped -d klaxon`
+`docker run -p 8885:3001 --name klaxon_local --env-file ./env_local.list --restart unless-stopped -d klaxon`
 
 ### Docker Compose
 

--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -18,6 +18,6 @@ services:
     env_file: 
       - env_local.list
     ports:
-      - change_me:3000
+      - change_me:3001
     # Example:
-    # - 8885:3000
+    # - 8885:3001

--- a/docs/local_setup_sans_docker.md
+++ b/docs/local_setup_sans_docker.md
@@ -64,8 +64,8 @@ In order to be allowed to login to Klaxon once it's running on your machine, it'
 
 ```
 ADMIN_EMAILS="my_awesome_email@gmail.com"
-HOST='localhost:3000'
-PORT=3000
+HOST='localhost:3001'
+PORT=3001
 ```
 
 Feel free to substitute in your email address. In development, Klaxon doesn't actually send emails locally, so a real address is not required.
@@ -83,7 +83,7 @@ Now, you should be about ready to get started. This command in the top folder of
 bin/dev
 ```
 
-Now, you should be able to go to [localhost:3000](http://localhost:3000/) in your web browser and see Klaxon's welcome screen pop up. You'll want to manually add a webpage or two to watch at [watching/pages/new](http://localhost:3000/watching/pages/new). For development purposes, you'll probably want to pick a site that updates pretty regularly. We use [http://www.timeanddate.com/](http://www.timeanddate.com/).
+Now, you should be able to go to [localhost:3001](http://localhost:3001/) in your web browser and see Klaxon's welcome screen pop up. You'll want to manually add a webpage or two to watch at [watching/pages/new](http://localhost:3001/watching/pages/new). For development purposes, you'll probably want to pick a site that updates pretty regularly. We use [http://www.timeanddate.com/](http://www.timeanddate.com/).
 
 To get Klaxon to check for updates on the pages you're watching, in another terminal window, run this rake command.
 

--- a/docs/local_setup_with_docker.md
+++ b/docs/local_setup_with_docker.md
@@ -6,8 +6,8 @@ These instructions assume you have Git, Homebrew, Postgres, Ruby, and Docker ins
 
 Let's start by setting up our environment. If you haven't already, create a `.env` file and add the following (populating with your own preferences, where applicable):
 ```
-HOST='localhost:3000'
-PORT=3000
+HOST='localhost:3001'
+PORT=3001
 
 # Database settings
 POSTGRES_USER=postgres
@@ -31,7 +31,7 @@ BROWSER=/dev/null
 Let's use our `docker-compose.yml` file to build our Docker image, create our empty Postgres database and spin up our app. Run:
 ```
 docker-compose up
-open http://localhost:3000
+open http://localhost:3001
 ```
 
 You should see a `PendingMigrationError` in your browser. You can either click the `Run pending migrations` button below the error description, or run:

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+# Preview all emails at http://localhost:3001/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
 
 end


### PR DESCRIPTION
Still getting a 500 error in the deployed app with logs complaining about the absence of `application.css`. Seems like the `KLAXON_COMPILE_ASSETS` was intended to handle allowing the compilation of stylesheets, so we're going to try that.