### PR TITLE
NAPPS-1423: set up email delivery

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,32 @@
+# production.rb OVERRIDES
+KLAXON_FORCE_SSL=false # IRL this should be true, but for local "prod" needs to be false
+KLAXON_COMPILE_ASSETS=true
+
+# App settings
+# add emails that you want to be able to authenticate as admin
+ADMIN_EMAILS="admin@news.org, other.admin@news.org"
+# port is likely 5432, db name is likely something like "klaxon"
+# cluster endpoint can be found in the RDS cluster: 
+# https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/accessing-monitoring.html
+DATABASE_URL=postgresql://<USERNAME>:<PASSWORD>@<CLUSTER ENDPOINT>:<PORT>/<DB NAME>
+# the port you want the app to run in, default is 3000, but can be changed if you use 3000 for other projects
+PORT=3000
+# we use our "dev" environment as a mirror of prod, and our "local" environment for local development
+RACK_ENV=production
+RAILS_ENV=production
+# Make sure the SECRET_KEY_BASE is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+SECRET_KEY_BASE=
+
+# Amazon SES (email delivery) settings
+SMTP_PROVIDER=SES
+SES_ADDRESS="email-smtp.<region>.amazonaws.com"
+# domain verified in your AWS account
+SES_DOMAIN="news.org"
+SES_PORT=587
+MAILER_FROM_ADDRESS=klaxon@news.org
+# To create a user and retrieve its credentials:
+# https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html#smtp-credentials-console
+SES_USERNAME=
+SES_PASSWORD=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,14 @@
+# in development, this just needs a value. Emails are not sent in dev.
+ADMIN_EMAILS="admin@news.org"
+HOST='localhost:3000'
+PORT=3000
+
+# App settings
+RACK_ENV=development
+RAILS_ENV=development
+# postgres URI pattern is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+DATABASE_URL="postgres://postgres:postgres@db:5432/klaxon"
+# a real secret_key_base value is only needed in prod environment
+SECRET_KEY_BASE="secret_key_base"
+LAUNCHY_DRY_RUN=true # stop letter_opener from attempting to open a browser
+BROWSER=/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pull_dev_database.sh
 
 snapshots
 .env*
+!.env.*.example

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -419,12 +419,12 @@ context:
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: true
       SMTP_PROVIDER: SES
-      SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:address}}"
-      SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:domain}}"
-      SES_PORT: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:port}}"
-      MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:mailerFromAddress}}"
-      SES_USERNAME: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:username}}"
-      SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:password}}"
+      SES_ADDRESS: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:address}}"
+      SES_DOMAIN: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:domain}}"
+      SES_PORT: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:port}}"
+      MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:mailerFromAddress}}"
+      SES_USERNAME: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:username}}"
+      SES_PASSWORD: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:password}}"
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -418,6 +418,13 @@ context:
       RAILS_ENV: production
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: true
+      SMTP_PROVIDER: SES
+      SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:address}}"
+      SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:domain}}"
+      SES_PORT: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:port}}"
+      MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:mailerFromAddress}}"
+      SES_USERNAME: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:username}}"
+      SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/secret-key:SecretString:password}}"
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -419,12 +419,12 @@ context:
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: true
       SMTP_PROVIDER: SES
-      SES_ADDRESS: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:address}}"
-      SES_DOMAIN: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:domain}}"
-      SES_PORT: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:port}}"
-      MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:mailerFromAddress}}"
-      SES_USERNAME: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:username}}"
-      SES_PASSWORD: "{{resolve:secretsmanager:/ /klaxon/ses-prod/smtp-user-credentialssecret-key:SecretString:password}}"
+      SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:address}}"
+      SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:domain}}"
+      SES_PORT: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:port}}"
+      MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:mailerFromAddress}}"
+      SES_USERNAME: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:username}}"
+      SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials/secret-key:SecretString:password}}"
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # config.action_mailer.delivery_method = :postmark
+  config.action_mailer.delivery_method = :smtp
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   Rails.application.routes.default_url_options[:host] = 'localhost:3001'
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.cache_classes = true # to run migrations locally, change to false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -86,7 +86,9 @@ Rails.application.configure do
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"
-  # if you use SES as your SMTP provider, then your username and password are actually your AWS credentials.
+  # if you use SES as your SMTP provider, then your username and password are actually your AWS user credentials.
+  # NOTE: AWS users are different from roles. If your team relies on roles to authenticate,
+  # you'll likely need to create a new user just to create SMTP credentials
   user_name = ENV["#{provider}_USERNAME" || (provider == "SES" ? (ENV["AWS_ACCESS_KEY_ID"] || ENV["ACCESS_KEY_ID"] ) : nil) ]  # for AWS SES, this is your access key id
   password  = ENV["#{provider}_PASSWORD" || (provider == "SES" ? (ENV["AWS_SECRET_ACCESS_KEY"] || ENV["SECRET_ACCESS_KEY"] ) : nil) ]  # for AWS SES, this is your secret access key
   domain    = ENV["#{provider}_DOMAIN"] || "heroku.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:14
     env_file:
-      - .env.dev
+      - .env.local
       - ~/.clokta/default.env
     ports:
       - "5432:5432"
@@ -15,7 +15,7 @@ services:
     ports: 
       - "3001:3001"
     env_file:
-      - .env.dev
+      - .env.local
       - ~/.clokta/default.env
     build: .
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   db:
     image: postgres:14
     env_file:
-      - .env.local
+      - .env.dev
+      - ~/.clokta/default.env
     ports:
       - "5432:5432"
     volumes:
@@ -14,7 +15,8 @@ services:
     ports: 
       - "3001:3001"
     env_file:
-      - .env.local
+      - .env.dev
+      - ~/.clokta/default.env
     build: .
     depends_on:
       - db

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -21,6 +21,8 @@ alias klaxon-psql="klaxon-psql-run psql"
 
 alias klaxon-migrate="klaxon-rails db:migrate"
 
+alias klaxon-create-admin="klaxon-rails users:create_admin"
+
 # Drop and re-create the DB, not just flushing data from tables
 klaxon-reset-db(){
     klaxon-psql-run sh -c "echo \"SELECT pg_terminate_backend(pg_stat_activity.pid) \
@@ -49,4 +51,5 @@ echo \"                              example: klaxon-rails db:migrate\"
 echo \"klaxon-psql              - drop into a psql shell\"
 echo \"klaxon-psql-container   - get the container ID of the postgres service\"
 echo \"klaxon-psql-run          - run a command on the running postgres container\"
+echo \"klaxon-create-admin      - add users for each comma-separated email in ADMIN_EMAILS\"
 "


### PR DESCRIPTION
Adds configuration for AWS SES to allow Klaxon to send emails

[NAPPS-1423](https://arcpublishing.atlassian.net/browse/NAPPS-1423?atlOrigin=eyJpIjoiYjIwYzcxZWJjNWM3NDY5OThhZDNmNmJkMGM1NDFlY2YiLCJwIjoiaiJ9)

To test:
- confirm references to secrets in Secrets Manager are as they should be in the dev cfn config
- use those references as a directory to populate your own `.env.dev` file (note: I use PORT: 3001 to avoid caching conflicts)
- put your own email address as one of the ADMIN_EMAILS values
- change the environment references in `docker-compose.yml` to point to your `.env.dev` file
- `docker-compose up`
- If needed, click the button in your browser to run pending migrations
- You should be able to see the welcome screen. Enter your email address and confirm you receive an email
- Contact Katlyn if any of this goes awry

[NAPPS-1423]: https://arcpublishing.atlassian.net/browse/NAPPS-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ