### PR TITLE
Temp fix/accepting 300-399 redirect for healthcheck statuses

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -332,7 +332,7 @@ context:
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:
-          HttpCode: "200-299"
+          HttpCode: "200-399" # accepts success or redirect
 
       dns:
         zone_apex: news-engineering.aws.wapo.pub.

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -335,7 +335,7 @@ context:
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:
-          HttpCode: "200-299"
+          HttpCode: "200-399" # accepts success or redirect
 
     dns:
       zone_apex: news-engineering.aws.wapo.pub.


### PR DESCRIPTION
It looks like our ECS tasks are failing because the healthchecks are redirecting and returning 300-399 status codes, which we do not have configured as a "healthy" response code. We are accepting 200-399 as "healthy" to see if we can diagnose this as the issue, and then we will evaluate whether it is stable to keep the 300s as healthy status codes.