### PR TITLE
NAPPS-1458: changing public protocol to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pull_dev_database.sh
 snapshots
 .env*
 !.env.*.example
+
+public/assets/

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -268,7 +268,7 @@ context:
       # protocol: string (default HTTP)
       # port: int (default 80)
 
-      public_protocol: http
+      public_protocol: https
       public_port: 443
       http_to_https_redirect: true
       certificate: arn:aws:acm:us-east-1:912288704264:certificate/c1ff8358-9b24-4e68-9d38-28caf63c0fde

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -332,7 +332,7 @@ context:
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:
-          HttpCode: "200-399" # accepts success or redirect
+          HttpCode: "200-299"
 
       dns:
         zone_apex: news-engineering.aws.wapo.pub.


### PR DESCRIPTION
Another proposed solution to this problem. I'm not sure why our `public_protocol` is set to `http` but I'm thinkingggggggg it's a typo. Just having a hard time fathoming that we are the only ones hitting up against this problem, so I wonder if this `public_protocol` and `public_port` are what's used as the default Load Balancer protocol and port, which it then uses to ping the healthchecker.

I think we should try this before [attempting to modify the template](https://github.com/WPMedia/klaxon/pull/16). What do you think, @aaronbrezel ?