### PR TITLE
Fix/adding vars to local env example needed to create local db

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,6 +3,12 @@ ADMIN_EMAILS="admin@news.org"
 HOST='localhost:3000'
 PORT=3000
 
+#DB settings needed only for db creation
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=klaxon
+POSTGRES_HOST=db
+
 # App settings
 RACK_ENV=development
 RAILS_ENV=development


### PR DESCRIPTION
The connection between the app and the db relies on `DATABASE_URL` but it turns out that the parsed environment variables (for the username, password, etc.) are still needed to create the database in the first place! This should not be a problem in the deployed databases because those are created manually.