### PR TITLE
NAPPS-1438: testing rails url host override in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,7 @@ Rails.application.configure do
 
   # uncomment locally, using 3001 to avoid conflict with our other applications
   # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+  Rails.application.routes.default_url_options[:host] = 'klaxon-dev.news-engineering.aws.wapo.pub'
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"


### PR DESCRIPTION
A little mystified that [this PR](https://github.com/WPMedia/klaxon/pull/19) seemed to not affect the root URL in the link sent to authenticate users (still localhost:3001) even though adjusting this value worked locally and the image seemed to be rebuilt.

[NAPPS-1438](https://arcpublishing.atlassian.net/browse/NAPPS-1438?atlOrigin=eyJpIjoiNWE1MzQ1NDUyYjAxNGNmZmE2OWI5MjcxODRlNDgzZDgiLCJwIjoiaiJ9)

[NAPPS-1438]: https://arcpublishing.atlassian.net/browse/NAPPS-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ