### PR TITLE
Fix/adding env file to db in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: postgres:14
     ports:
       - "5432:5432"
+    env_file:
+      - .env.dev
     volumes:
       - postgres_data_local:/var/lib/postgresql/data
 


### PR DESCRIPTION
@aaronbrezel posed a great question several days back about why the `db` would need access to the environment variables given that the app is the one that needs those credentials to access the app. Without a good answer, I deleted them to see if everything worked, but the `db` does need them — for initializing! Silly me. S/o to @emlorraine for bearing with me as I sort out what can and can't be nixed.