### PR TITLE
Revert "NAPPS-1438: testing rails url host override in prod"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,6 @@ Rails.application.configure do
 
   # uncomment locally, using 3001 to avoid conflict with our other applications
   # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
-  Rails.application.routes.default_url_options[:host] = 'klaxon-dev.news-engineering.aws.wapo.pub'
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"


### PR DESCRIPTION
Reverts WPMedia/klaxon#22

To recap: before merging this PR, the root URL in the welcome email sent by the deployed app was localhost:3001. This was weird because I had just removed the line that overrode the default localhost:3000 and replaced it with localhost:3001. To make things weirder, adding this line as a test of whether I could force the root URL to be `klaxon-dev.news-engineering.aws.wapo.pub` instead resulted in the root URL being localhost:3000. 

It's weird to say, but it feels like the app is hanging always on the second to most recent change. Reading more about how Rails sets the default host to see if I'm just going about this the wrong way.