### PR TITLE
Fix/mirror dev cfn config changes in prod

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -331,7 +331,7 @@ context:
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:
-          HttpCode: "200-399" # accepts success or redirect
+          HttpCode: "200-299"
 
       dns:
         zone_apex: news-engineering.aws.wapo.pub.
@@ -413,6 +413,7 @@ context:
       DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
       ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
       PORT: 3001
+      APP_HOST: klaxon-dev.news-engineering.aws.wapo.pub.
       RACK_ENV: production
       RAILS_ENV: production
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -271,9 +271,8 @@ context:
       # protocol: string (default HTTP)
       # port: int (default 80)
 
-      public_protocol: http
+      public_protocol: HTTPS
       public_port: 443
-      http_to_https_redirect: true
       certificate: arn:aws:acm:us-east-1:912288704264:certificate/c1ff8358-9b24-4e68-9d38-28caf63c0fde
 
       # public_protocol: HTTP / HTTPS / TCP / UDP / TCP_UDP / TLS (default router.protocol)
@@ -329,7 +328,7 @@ context:
       #   this structure defines the parameters of a health check, the defaults are below
       #
       health_check:
-        path: "/healthcheck/"
+        path: "/healthcheck"
         interval_seconds: 10
         timeout_seconds: 5
         healthy_threshold_count: 2

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -334,7 +334,7 @@ context:
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:
-          HttpCode: "200-399" # accepts success or redirect
+          HttpCode: "200-299"
 
     dns:
       zone_apex: news-engineering.aws.wapo.pub.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,9 +81,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
-  # uncomment locally, using 3001 to avoid conflict with our other applications
-  # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
-  Rails.application.routes.default_url_options[:host] = 'klaxon-dev.news-engineering.aws.wapo.pub'
+  # ensuring root url in emails is correct for deployed app and local development
+  Rails.application.routes.default_url_options[:host] = (ENV["APP_HOST"] || 'localhost:3001')
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"


### PR DESCRIPTION
There were some wonky things in the prod CFN config, and the env variables needed to be populated with paths to Secrets Manager. Once these changes are merged in, I believe it'll be ready for this [group-news PR](https://github.com/WPMedia/aws-group-news-engineering/pull/458) to merge in and the resources be deployed to prod! (cc @emlorraine)