### PR TITLE
Re-adding the http to https redirect as test

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -271,7 +271,8 @@ context:
       public_protocol: HTTPS
       public_port: 443
       certificate: arn:aws:acm:us-east-1:912288704264:certificate/c1ff8358-9b24-4e68-9d38-28caf63c0fde
-
+      http_to_https_redirect: true
+      
       # public_protocol: HTTP / HTTPS / TCP / UDP / TCP_UDP / TLS (default router.protocol)
       #   this defines the Listener Protocol
       #   if HTTP or HTTPS then an ALB (Application Load Balancer) is created


### PR DESCRIPTION
Re-adding this line as an attempt to work our way back to the app state where healthchecks were clearly being conducted and passing, even if it wasn't ideal because we had to accept redirect (300-399) status codes as healthy.