### PR TITLE
Fix/changing url in email based on environment

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -412,10 +412,11 @@ context:
 
     environment:
       DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
-      ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
+      ADMIN_EMAILS: "admin@news.org"
       PORT: 3001
       RACK_ENV: production
       RAILS_ENV: production
+      HOST_URL: "klaxon-dev.news-engineering.aws.wapo.pub"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: true
       SMTP_PROVIDER: SES

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
-  # uncomment locally, using 3001 to avoid conflict with our other applications
-  # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+  # changes the root url used in the email link, depending on environment
+  Rails.application.routes.default_url_options[:host] = (ENV["HOST_URL"] || "localhost:3001")
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"


### PR DESCRIPTION
Hoping that this change allows us to test the Klaxon production environment locally with `localhost:3001` but in the deployed app should change the root URL to the app's URL. Must deploy to test this change.