### PR TITLE
Fix/lower num tasks scaling

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -412,10 +412,11 @@ context:
 
     environment:
       DATABASE_URL: "postgresql://{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:username}}:{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:password}}@{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:writer-host}}:5432/klaxon"
-      ADMIN_EMAILS: "erik.reyna@washpost.com, armand.emamdjomeh@washpost.com, katlyn.alo@washpost.com"
+      ADMIN_EMAILS: "admin@news.org"
       PORT: 3001
       RACK_ENV: production
       RAILS_ENV: production
+      HOST_URL: "klaxon-dev.news-engineering.aws.wapo.pub"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: true
       SMTP_PROVIDER: SES

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -518,9 +518,9 @@ context:
     disable: false
 
     # default max is 12X the service.default_scale
-    max: 20
+    max: 12
     # default min is the default_scale
-    min: 2
+    min: 1
 
     #Additional configurable properties with their defaults:
     cpu_target: 50

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
-  # uncomment locally, using 3001 to avoid conflict with our other applications
-  # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+  # changes the root url used in the email link, depending on environment
+  Rails.application.routes.default_url_options[:host] = (ENV["HOST_URL"] || "localhost:3001")
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"


### PR DESCRIPTION
Not sure why, but lots of tasks are getting spun up and it seems that it's _causing_ rather than _a result of_ high CPU/memory usage. Lowering the max and min values to see what that impacts. Noting that the app loads a lot faster right after an initial redeploy when fewer tasks are spun up.