### PR TITLE
test/turning off autoscaling

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -517,7 +517,7 @@ context:
   # `container.memory_reservation` will impact scaling behavior.
   scaling:
     # Autoscaling is enabled by default. use `true` to turn it off
-    disable: false
+    disable: true
 
     # default max is 12X the service.default_scale
     max: 12


### PR DESCRIPTION
Trying to understand why our ECS cluster is spinning up so many tasks, even when no one is actively using the app. Turning off autoscaling to see how that affects performance. It appears some of our other apps don't utilize autoscaling — hoping this is sufficient for our team's needs.