### PR TITLE
Test/increasing healthcheck timeout

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -328,7 +328,7 @@ context:
       health_check:
         path: "/healthcheck"
         interval_seconds: 30
-        timeout_seconds: 5
+        timeout_seconds: 10
         healthy_threshold_count: 2
         unhealthy_threshold_count: 6
         matcher:


### PR DESCRIPTION
It appears the healthchecks are timing out, leaving the ECS tasks in an unhealthy state. Visiting the `/healthcheck` endpoint returns a quick 200 status, so we aren't sure what's going on there. But, as we're switching from HTTP to HTTPS, we might want to increase the timeout to the [AWS default for HTTPS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds).