### PR TITLE
Napps-1472: `rake check:all` cronjob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,16 @@ FROM public.ecr.aws/docker/library/ruby:2.7.6
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
+# Install cron
+RUN apt-get -y update && apt-get install -y cron
+# Create the log file to be able to store logs
+RUN touch /var/log/cron.log
+# Cron (at least in Debian) does not execute crontabs with more than 1 hardlink, see bug 647193.
+# As Docker uses overlays, it results with more than one link to the file, so you have to touch
+# it in your startup script, so the link is severed.
+RUN touch /etc/crontab /etc/cron.*/*
+
+
 # Set up the app directory
 WORKDIR /usr/src/app
 
@@ -28,7 +38,12 @@ RUN bundle install
 # Copy over the rest of the app
 COPY . .
 
+RUN ["chmod", "+x", "./docker-entrypoint.sh"]
+
 EXPOSE 3001
 
-CMD ["bundle", "exec", "rails", "assets:precompile"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# As written this first command will not execute since it's the first of two `CMD`s
+CMD ["bundle", "exec", "rails", "assets:precompile"] 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
   # uncomment locally, using 3001 to avoid conflict with our other applications
-  # Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+  Rails.application.routes.default_url_options[:host] = 'localhost:3001'
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "5432:5432"
     env_file:
-      - .env.dev
+      - .env.local
     volumes:
       - postgres_data_local:/var/lib/postgresql/data
 
@@ -14,7 +14,7 @@ services:
     ports: 
       - "3001:3001"
     env_file:
-      - .env.dev
+      - .env.local
     build: .
     depends_on:
       - db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Add crontab jobs
+echo "Calling script to set up server cronjobs"
+/bin/bash scripts/cron_setup.sh
+
+pwd
+bundle show
+echo "skip skip skip skip skip"
+
+# Launch the main container command passed as arguments.
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,9 +4,5 @@
 echo "Calling script to set up server cronjobs"
 /bin/bash scripts/cron_setup.sh
 
-pwd
-bundle show
-echo "skip skip skip skip skip"
-
 # Launch the main container command passed as arguments.
 exec "$@"

--- a/scripts/cron_setup.sh
+++ b/scripts/cron_setup.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-echo "Beepity boop I am setting up a cron job"
+# Pass environment variables to the crontab env.
+# This is critical for the cron service to be able to execute bundle in the right
+# configuration
+env >> /etc/environment
 
 # Add cron job to crontab
+# cd into klaxon root dir and run rake command to check for website changes
+(echo "*/10 * * * * /bin/bash -l -c 'cd /usr/src/app && bundle exec rake check:all' > /proc/1/fd/1 2>&1") | crontab
 # We redirect the output of the cron job (> /proc/1/fd/1 2>&1) so that it will be
 # included in standard error / out.
 # For more context: https://gist.github.com/mowings/59790ae930accef486bfb9a417e9d446
-
-(echo "*/1 * * * * /bin/bash -l -c 'cd /usr/src/app && pwd && bundle show' > /proc/1/fd/1 2>&1") | crontab
-
-#cd /usr/src/app && bundle exec rake check:all
 
 echo "Starting cron ..."
 # Run cron in the foreground, but make it not block subsequent processes

--- a/scripts/cron_setup.sh
+++ b/scripts/cron_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Beepity boop I am setting up a cron job"
+
+# Add cron job to crontab
+# We redirect the output of the cron job (> /proc/1/fd/1 2>&1) so that it will be
+# included in standard error / out.
+# For more context: https://gist.github.com/mowings/59790ae930accef486bfb9a417e9d446
+
+(echo "*/1 * * * * /bin/bash -l -c 'cd /usr/src/app && pwd && bundle show' > /proc/1/fd/1 2>&1") | crontab
+
+#cd /usr/src/app && bundle exec rake check:all
+
+echo "Starting cron ..."
+# Run cron in the foreground, but make it not block subsequent processes
+cron start


### PR DESCRIPTION
# Description

Most Klaxon deployments use Heroku, which utilizes a feature called "Heroku Scheduler" to run the command `rake check:all` on the running server every 10 minutes. [This section of the Klaxon documentation](https://github.com/WPMedia/klaxon#lets-do-this) goes into more detail.

Because we do not deploy with Heroku, we need another way to run this command. Our solution is a cronjob that we set up when our Klaxon server spins up. 

This is basically a SO copy-pasta addition from [a similar feature](https://github.com/WPMedia/policeshootings/pull/530/files) we added to the policeshootings repo. 

# Ticket

[NAPPS-1472]

# Testing steps 

Checkout this branch and spin up an instance of Klaxon:
```
docker-compose up
```
**Note:** make sure you're using `.env.local` within `docker-compose.yml` instead of `.env.dev` 

If you're not signed in already, you can sign in to Klaxon using the email: "admin@news.org"

Next, manually watch a page by navigating to http://localhost:3001/watching/pages and selecting the "Manually Watch an Item" 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/35546183/216396155-a40ef35e-0f57-40c8-b06f-a6100aa52316.png">

On the next page, fill out the form like so:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/35546183/216396830-2f899419-6346-44cd-95e9-df18fa857333.png">

here's the css selector for you to copy-paste: `div.four:nth-child(1) > div:nth-child(1)`

Once the page is "watched", navigate to the "feed" page. Wait 10 minutes, and you should see the feed populated by updated messages like so: 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/35546183/216398070-650b22d9-dda7-420d-9d1e-b9d0f5f1b31b.png">
 



[NAPPS-1472]: https://arcpublishing.atlassian.net/browse/NAPPS-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ