### PR TITLE
fix/precompile assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,4 @@ EXPOSE 3001
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-# As written this first command will not execute since it's the first of two `CMD`s
-CMD ["bundle", "exec", "rails", "assets:precompile"] 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,5 +4,10 @@
 echo "Calling script to set up server cronjobs"
 /bin/bash scripts/cron_setup.sh
 
+echo "precompiled %%%%%%%%%%%%%%%%%%%%"
+bundle exec rails assets:precompile
+
 # Launch the main container command passed as arguments.
 exec "$@"
+
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 echo "Calling script to set up server cronjobs"
 /bin/bash scripts/cron_setup.sh
 
-echo "precompiled %%%%%%%%%%%%%%%%%%%%"
+# Compile static assets before launching server
 bundle exec rails assets:precompile
 
 # Launch the main container command passed as arguments.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,5 +9,3 @@ bundle exec rails assets:precompile
 
 # Launch the main container command passed as arguments.
 exec "$@"
-
-


### PR DESCRIPTION
A small adjustment to precompile Klaxon assets before deploying the app. 

You can test this change by rebuilding the docker image and deploying:

```
docker-compose up --build --force-recreate
```

Note how lightning-quick the app loads now