### PR TITLE
Fix/exclude healthcheck from force_ssl in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = (ENV.fetch('KLAXON_FORCE_SSL', 'true').to_s.downcase == 'true')
+  # force_ssl above breaks the healthcheck, returning a 300 status instead of 200
+  # this should allow an ssl exception, per https://api.rubyonrails.org/v5.2.1/classes/ActionDispatch/SSL.html
+  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Even after removing `http_https_redirect: true` from our CFN config, our healthchecks are failing with a 301 status code. According to [this here thread](https://github.com/Purple-Devs/health_check/issues/25) it could be because our `force_ssl` setting is redirecting the healthcheck, so this is an attempt at forcing an exception for that specific path.

To test, you can confirm that hitting the /healthcheck endpoint locally still works, but then I think we must deploy.