### PR TITLE
Fix/repairing prod config dns sytax

### DIFF
--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -335,9 +335,9 @@ context:
         matcher:
           HttpCode: "200-299"
 
-    dns:
-      zone_apex: news-engineering.aws.wapo.pub.
-      domain: klaxon-prod.news-engineering.aws.wapo.pub.
+      dns:
+        zone_apex: news-engineering.aws.wapo.pub.
+        domain: klaxon-prod.news-engineering.aws.wapo.pub.
     # #  If you are using either `import_listener`  or `import_target_group`above,
     # #  you need to import the canonical hosted zone of the load balancer
     # #  and the dns name of the load balancer here


### PR DESCRIPTION
There was a syntax problem with the DNS config. This PR fixes that issue to fix the failing deployment. 