### PR TITLE
fix/route healthcheck through /klaxon/healthcheck

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -325,7 +325,7 @@ context:
       #   this structure defines the parameters of a health check, the defaults are below
       #
       health_check:
-        path: "/healthcheck"
+        path: "/klaxon/healthcheck"
         interval_seconds: 30
         timeout_seconds: 10
         healthy_threshold_count: 2

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -327,7 +327,7 @@ context:
       #   this structure defines the parameters of a health check, the defaults are below
       #
       health_check:
-        path: "/healthcheck"
+        path: "/klaxon/healthcheck"
         interval_seconds: 10
         timeout_seconds: 5
         healthy_threshold_count: 2


### PR DESCRIPTION
We are not seeing the changes from #42 applied in the dev deployed version of the app. Our hunch is that we forgot to apply a healthcheck route alteration.