### PR TITLE
NAPPS-1590: set desired tasks on prod klaxon app to 1

### DIFF
--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -55,7 +55,7 @@ context:
     # default_scale: int
     #   Define the number of service-instances that should be run within the cluster
     #   Note: coordinate this with your auto-scaling behavior in the scaling section
-    default_scale: 3
+    default_scale: 1 # temp while autoscaling is turned off
 
     # network_mode: string
     #   controls how Docker exposes the service to the network


### PR DESCRIPTION
We want to temporarily reduce the number of tasks running the prod klaxon app to 1. 

In order to do this, we must update the config template to set our desired tasks to 1, not 3