### PR TITLE
Napps 1591: Split dockerfiles for rake command

### DIFF
--- a/Dockerfile.rake
+++ b/Dockerfile.rake
@@ -1,0 +1,32 @@
+FROM public.ecr.aws/docker/library/ruby:2.7.7
+
+# Throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+# Set up the app directory
+WORKDIR /usr/src/app
+
+# Configure bundler
+ENV LANG=C.UTF-8 \
+    BUNDLE_JOBS=4 \
+    BUNDLE_RETRY=3
+
+# Store Bundler settings in the project's root
+ENV BUNDLE_APP_CONFIG=.bundle
+
+# Upgrade RubyGems and install the latest Bundler version
+RUN gem update --system && \
+    gem install bundler
+
+# Copy over the dependency files
+COPY Gemfile .
+COPY Gemfile.lock .
+
+# Install dependencies
+RUN bundle install
+
+# Copy over the rest of the app
+COPY . .
+
+CMD ["bundle", "exec", "rake", "check:all"]
+

--- a/Dockerfile.rake
+++ b/Dockerfile.rake
@@ -29,4 +29,3 @@ RUN bundle install
 COPY . .
 
 CMD ["bundle", "exec", "rake", "check:all"]
-

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/ruby:2.7.7
 
-# Throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
+ARG USE_CRON=false
+ENV USE_CRON=${USE_CRON}
 
 # Install cron
 RUN apt-get -y update && apt-get install -y cron
@@ -12,6 +12,8 @@ RUN touch /var/log/cron.log
 # it in your startup script, so the link is severed.
 RUN touch /etc/crontab /etc/cron.*/*
 
+# Throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
 
 # Set up the app directory
 WORKDIR /usr/src/app
@@ -43,5 +45,6 @@ RUN ["chmod", "+x", "./docker-entrypoint.sh"]
 EXPOSE 3001
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
+
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -46,5 +46,4 @@ EXPOSE 3001
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/app/views/sessions/unknown_user.html.erb
+++ b/app/views/sessions/unknown_user.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-      <p class="lead">If you have an existing account, you might have typed your email wrong. <a href="/">Try again.</a> If not, contact your adminstrator.</p>
+      <p class="lead">If you have an existing account, you might have typed your email wrong. <a href="/klaxon">Try again.</a> If not, contact your adminstrator.</p>
       </div>
       <div class="col-md-6">
         <!-- negative space -->

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ env:
     # APP_NAME must match that of the ecr image repo
     # see cfn/configs/image/us-east-1/config.yml context.name
     APP_NAME: klaxon
-    DOCKERFILE_PATH: ./Dockerfile
+    DOCKERFILE_SERVER_PATH: ./Dockerfile.server # For the klaxon server
 
 phases:
   install:
@@ -23,8 +23,13 @@ phases:
 
   build:
     on-failure: ABORT
-    commands:
-      - docker build --cache-from $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$APP_NAME:$DEPLOYMENT_ENV-latest -t $APP_NAME:$DEPLOYMENT_ENV-`cat commit_hash` -f $DOCKERFILE_PATH .
+    commands: # Temporarily set USE_CRON=true while we debug ECS scheduled task
+      - | 
+        docker build \
+          --cache-from $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$APP_NAME:$DEPLOYMENT_ENV-latest \
+          --build-arg USE_CRON=true \ 
+          -t $APP_NAME:$DEPLOYMENT_ENV-`cat commit_hash` \ 
+          -f $DOCKERFILE_SERVER_PATH .
 
   post_build:
     commands:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,18 @@ services:
       - "3001:3001"
     env_file:
       - .env.local
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      # args:
+      #   - USE_CRON=true
+    depends_on:
+      - db
+  rake:
+    env_file:
+      - .env.local
+    build:
+      context: .
+      dockerfile: Dockerfile.rake
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
-      # args:
-      #   - USE_CRON=true
+      args:
+        - USE_CRON=true
     depends_on:
       - db
   rake:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,3 @@ services:
         - USE_CRON=true
     depends_on:
       - db
-  rake:
-    env_file:
-      - .env.local
-    build:
-      context: .
-      dockerfile: Dockerfile.rake
-    depends_on:
-      - db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,13 +4,13 @@ if [[ "$USE_CRON" == "true" ]]; then
     # Add crontab jobs
     echo "Calling script to set up server cronjobs"
     /bin/bash scripts/cron_setup.sh
+    
+    # Initialize app with initial diff check on watched pages
+    echo "Initial check on watched pages" 
+    bundle exec rake check:all
 else
     echo "Skipping cron setup"
 fi
-
-# Initialize app with initial diff check on watched pages
-echo "Initial check on watched pages" 
-bundle exec rake check:all
 
 # Compile static assets before launching server
 bundle exec rails assets:precompile

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,9 @@ else
     echo "Skipping cron setup"
 fi
 
+# Initialize app with initial diff check on watched pages
+echo "Initial check on watched pages" 
+bundle exec rake check:all
 
 # Compile static assets before launching server
 bundle exec rails assets:precompile

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Add crontab jobs
-echo "Calling script to set up server cronjobs"
-/bin/bash scripts/cron_setup.sh
+if [[ "$USE_CRON" == "true" ]]; then
+    # Add crontab jobs
+    echo "Calling script to set up server cronjobs"
+    /bin/bash scripts/cron_setup.sh
+else
+    echo "Skipping cron setup"
+fi
+
 
 # Compile static assets before launching server
 bundle exec rails assets:precompile


### PR DESCRIPTION
This PR adds a new dockerfile dedicated to the `rake check:all` command. For clarity, the original Klaxon server `Dockerfile` has been deleted--with `Dockerfile.server` and `Dockerfile.rake` replacing it. Both Dockerfiles will employ the exact same build setup. 

The primary difference is the entrypoint command. For `Dockerfile.server` we use the same entrypoint as the original `Dockerfile`. The `Dockerfile.rake` image will execute `rake check:all` instead. 

The image created by `Dockerfile.rake` will end up being used by the ECS scheduled task described in [NAPPS-1591]. 

The only other change of note, is the optional build arg in `Dockerfile.server` which allows local developers to continue using the cron job to run `rake check:all` despite it being phased out of production. 

## To test

Run 
```
docker-compose up --build --force-recreate
```

We should see three bits of behavior on startup 
1. Three containers should be built: `klaxon-db-1`, `klaxon-app-1` and `klaxon-rake-1`. 
2. `klaxon-rake-1` should execute a `rake check:all` command (with email style output) and terminal safely
3. `klaxon-db-1` and `klaxon-app-1` should continue as they always have, creating a working Klaxon server. 
4. After 10 minutes, you should see `klaxon-app-1` execute `rake check:all` through its cron timer. 


[NAPPS-1591]: https://arcpublishing.atlassian.net/browse/NAPPS-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ