### PR TITLE
NAPPS 1592: Create ECS scheduled task

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,11 +23,10 @@ phases:
 
   build:
     on-failure: ABORT
-    commands: # Temporarily set USE_CRON=true while we debug ECS scheduled task
+    commands:
       - | 
         docker build \
           --cache-from $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$APP_NAME:$DEPLOYMENT_ENV-latest \
-          --build-arg USE_CRON=true \
           -t $APP_NAME:$DEPLOYMENT_ENV-`cat commit_hash` \
           -f $DOCKERFILE_SERVER_PATH .
 

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -31,6 +31,9 @@ template: v1/cfn/shared/apps/ecs-v2/service.template.yml
 stack_name: *STACK_NAME
 region: *REGION
 
+include:
+  - cfn/ecs-task/configs/dev/us-east-1/config.yml
+
 context:
   debug: *DEBUG
   name: *SERVICE_NAME

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -31,8 +31,8 @@ template: v1/cfn/shared/apps/ecs-v2/service.template.yml
 stack_name: *STACK_NAME
 region: *REGION
 
-include:
-  - cfn/ecs-task/configs/prod/us-east-1/config.yml
+# include:
+#   - cfn/ecs-task/configs/prod/us-east-1/config.yml
 
 context:
   debug: *DEBUG

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -31,6 +31,9 @@ template: v1/cfn/shared/apps/ecs-v2/service.template.yml
 stack_name: *STACK_NAME
 region: *REGION
 
+include:
+  - cfn/ecs-task/configs/prod/us-east-1/config.yml
+
 context:
   debug: *DEBUG
   name: *SERVICE_NAME

--- a/cfn/ecs-task/configs/dev/us-east-1/config.yml
+++ b/cfn/ecs-task/configs/dev/us-east-1/config.yml
@@ -1,0 +1,41 @@
+_globals:
+  # This section is used to accumulate the YAML Anchors for use in the config to DRY the configs
+  # This is done to reduce errors due to copying configs from one env/region to another
+
+  - &CLUSTER_PREFIX newsroom
+  - &DEBUG false
+
+  # Assuming a config file is named as follows
+  # e.g. cfn/config/MyFirstService/dev/us-east-1/config.yml
+
+  # The following two lines extract information from the stackjack config file being executed
+  - &FILEPATH "{{ config_file_name }}"
+  - !_split &FILENAME [!_split [*FILEPATH, "/", 0, -1], ".", 0, 0]
+
+  # Other information including service name, environment and region are further extracted from the file path
+  - !_split &SERVICE_NAME [*FILEPATH, "/", 0, 2]
+  - !_split &ENVIRONMENT [*FILEPATH, "/", 0, 3]
+  - !_split &REGION [*FILEPATH, "/", 0, 4]
+
+  # Or can be statically defined
+  #- &SERVICE_NAME           MyFirstService
+  #- &ENVIRONMENT            dev
+  #- &REGION                 us-east-1
+
+  # Lastly we assemble the ClusterName and StackName based on data collected above
+  #
+  - !_join &CLUSTER_NAME ["-", *CLUSTER_PREFIX, *ENVIRONMENT]
+  - !_join &STACK_NAME ["-", *CLUSTER_NAME, *SERVICE_NAME]
+
+template: cfn/ecs-task/templates/ecs-task.template.yml
+stack_name: *STACK_NAME
+region: *REGION
+
+context:
+  debug: *DEBUG
+  name: *SERVICE_NAME
+  environment: *ENVIRONMENT
+  cluster_name: *CLUSTER_NAME
+  family: email-dev-ecs
+  image_name: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:dev-latest
+  schedule_expression: "*/10 * * * *"

--- a/cfn/ecs-task/configs/prod/us-east-1/config.yml
+++ b/cfn/ecs-task/configs/prod/us-east-1/config.yml
@@ -1,0 +1,41 @@
+_globals:
+  # This section is used to accumulate the YAML Anchors for use in the config to DRY the configs
+  # This is done to reduce errors due to copying configs from one env/region to another
+
+  - &CLUSTER_PREFIX newsroom
+  - &DEBUG false
+
+  # Assuming a config file is named as follows
+  # e.g. cfn/config/MyFirstService/dev/us-east-1/config.yml
+
+  # The following two lines extract information from the stackjack config file being executed
+  - &FILEPATH "{{ config_file_name }}"
+  - !_split &FILENAME [!_split [*FILEPATH, "/", 0, -1], ".", 0, 0]
+
+  # Other information including service name, environment and region are further extracted from the file path
+  - !_split &SERVICE_NAME [*FILEPATH, "/", 0, 2]
+  - !_split &ENVIRONMENT [*FILEPATH, "/", 0, 3]
+  - !_split &REGION [*FILEPATH, "/", 0, 4]
+
+  # Or can be statically defined
+  #- &SERVICE_NAME           MyFirstService
+  #- &ENVIRONMENT            dev
+  #- &REGION                 us-east-1
+
+  # Lastly we assemble the ClusterName and StackName based on data collected above
+  #
+  - !_join &CLUSTER_NAME ["-", *CLUSTER_PREFIX, *ENVIRONMENT]
+  - !_join &STACK_NAME ["-", *CLUSTER_NAME, *SERVICE_NAME]
+
+template: cfn/ecs-task/templates/ecs-task.template.yml
+stack_name: *STACK_NAME
+region: *REGION
+
+context:
+  debug: *DEBUG
+  name: *SERVICE_NAME
+  environment: *ENVIRONMENT
+  cluster_name: *CLUSTER_NAME
+  family: email-prod-ecs
+  image_name: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:prod-latest
+  schedule_expression: "*/10 * * * *"

--- a/cfn/ecs-task/configs/prod/us-east-1/config.yml
+++ b/cfn/ecs-task/configs/prod/us-east-1/config.yml
@@ -1,41 +1,41 @@
-_globals:
-  # This section is used to accumulate the YAML Anchors for use in the config to DRY the configs
-  # This is done to reduce errors due to copying configs from one env/region to another
+# _globals:
+#   # This section is used to accumulate the YAML Anchors for use in the config to DRY the configs
+#   # This is done to reduce errors due to copying configs from one env/region to another
 
-  - &CLUSTER_PREFIX newsroom
-  - &DEBUG false
+#   - &CLUSTER_PREFIX newsroom
+#   - &DEBUG false
 
-  # Assuming a config file is named as follows
-  # e.g. cfn/config/MyFirstService/dev/us-east-1/config.yml
+#   # Assuming a config file is named as follows
+#   # e.g. cfn/config/MyFirstService/dev/us-east-1/config.yml
 
-  # The following two lines extract information from the stackjack config file being executed
-  - &FILEPATH "{{ config_file_name }}"
-  - !_split &FILENAME [!_split [*FILEPATH, "/", 0, -1], ".", 0, 0]
+#   # The following two lines extract information from the stackjack config file being executed
+#   - &FILEPATH "{{ config_file_name }}"
+#   - !_split &FILENAME [!_split [*FILEPATH, "/", 0, -1], ".", 0, 0]
 
-  # Other information including service name, environment and region are further extracted from the file path
-  - !_split &SERVICE_NAME [*FILEPATH, "/", 0, 2]
-  - !_split &ENVIRONMENT [*FILEPATH, "/", 0, 3]
-  - !_split &REGION [*FILEPATH, "/", 0, 4]
+#   # Other information including service name, environment and region are further extracted from the file path
+#   - !_split &SERVICE_NAME [*FILEPATH, "/", 0, 2]
+#   - !_split &ENVIRONMENT [*FILEPATH, "/", 0, 3]
+#   - !_split &REGION [*FILEPATH, "/", 0, 4]
 
-  # Or can be statically defined
-  #- &SERVICE_NAME           MyFirstService
-  #- &ENVIRONMENT            dev
-  #- &REGION                 us-east-1
+#   # Or can be statically defined
+#   #- &SERVICE_NAME           MyFirstService
+#   #- &ENVIRONMENT            dev
+#   #- &REGION                 us-east-1
 
-  # Lastly we assemble the ClusterName and StackName based on data collected above
-  #
-  - !_join &CLUSTER_NAME ["-", *CLUSTER_PREFIX, *ENVIRONMENT]
-  - !_join &STACK_NAME ["-", *CLUSTER_NAME, *SERVICE_NAME]
+#   # Lastly we assemble the ClusterName and StackName based on data collected above
+#   #
+#   - !_join &CLUSTER_NAME ["-", *CLUSTER_PREFIX, *ENVIRONMENT]
+#   - !_join &STACK_NAME ["-", *CLUSTER_NAME, *SERVICE_NAME]
 
-template: cfn/ecs-task/templates/ecs-task.template.yml
-stack_name: *STACK_NAME
-region: *REGION
+# template: cfn/ecs-task/templates/ecs-task.template.yml
+# stack_name: *STACK_NAME
+# region: *REGION
 
-context:
-  debug: *DEBUG
-  name: *SERVICE_NAME
-  environment: *ENVIRONMENT
-  cluster_name: *CLUSTER_NAME
-  family: email-prod-ecs
-  image_name: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:prod-latest
-  schedule_expression: "*/10 * * * *"
+# context:
+#   debug: *DEBUG
+#   name: *SERVICE_NAME
+#   environment: *ENVIRONMENT
+#   cluster_name: *CLUSTER_NAME
+#   family: email-prod-ecs
+#   image_name: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:prod-latest
+#   schedule_expression: "*/10 * * * *"

--- a/cfn/ecs-task/templates/ecs-task.template.yml
+++ b/cfn/ecs-task/templates/ecs-task.template.yml
@@ -1,11 +1,13 @@
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html
 ---
 AWSTemplateFormatVersion: 2010-09-09
+
 Description: CloudFormation template for an ECS task definition
+
 Parameters:
   Family:
     Type: String
-    Default: "{{ family }}"
+    Default: {{ family }}
   Cpu:
     Type: Number
     Default: 256
@@ -19,24 +21,12 @@ Parameters:
     Type: String
   TaskRoleArn:
     Type: String
-  ContainerName:
-    Type: String
-    Default: "{{ container_name }}"
   ImageName:
     Type: String
-    Default: "{{ image_name }}"
-  EnvVarName:
-    Type: String
-    Default: "{{ env_var_name }}"
-  EnvVarValue:
-    Type: String
-    Default: "{{ env_var_value }}"
-  Command:
-    Type: List<String>
-    Default: "{{ command }}"
+    Default: {{ image_name }}
   ScheduleExpression:
     Type: String
-    Default: "{{ schedule_expression }}" # A cron or rate expression
+    Default: {{ schedule_expression }} 
 Resources:
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -50,7 +40,3 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref ContainerName
           Image: !Ref ImageName
-          Environment:
-            - Name: !Ref EnvVarName
-              Value: !Ref EnvVarValue
-          Command: !Ref Command

--- a/cfn/templates/ecs-task.template.yml
+++ b/cfn/templates/ecs-task.template.yml
@@ -1,0 +1,56 @@
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for an ECS task definition
+Parameters:
+  Family:
+    Type: String
+    Default: "{{ family }}"
+  Cpu:
+    Type: Number
+    Default: 256
+  Memory:
+    Type: Number
+    Default: 512
+  NetworkMode:
+    Type: String
+    Default: bridge
+  ExecutionRoleArn:
+    Type: String
+  TaskRoleArn:
+    Type: String
+  ContainerName:
+    Type: String
+    Default: "{{ container_name }}"
+  ImageName:
+    Type: String
+    Default: "{{ image_name }}"
+  EnvVarName:
+    Type: String
+    Default: "{{ env_var_name }}"
+  EnvVarValue:
+    Type: String
+    Default: "{{ env_var_value }}"
+  Command:
+    Type: List<String>
+    Default: "{{ command }}"
+  ScheduleExpression:
+    Type: String
+    Default: "{{ schedule_expression }}" # A cron or rate expression
+Resources:
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref Family
+      Cpu: !Ref Cpu
+      Memory: !Ref Memory
+      NetworkMode: !Ref NetworkMode
+      ExecutionRoleArn: !Ref ExecutionRoleArn
+      TaskRoleArn: !Ref TaskRoleArn
+      ContainerDefinitions:
+        - Name: !Ref ContainerName
+          Image: !Ref ImageName
+          Environment:
+            - Name: !Ref EnvVarName
+              Value: !Ref EnvVarValue
+          Command: !Ref Command


### PR DESCRIPTION
This PR introduces a new template to implement Docker images as ECS tasks. The template is based on the [AWS Cloudformation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html). We take a Docker image and a schedule expression to format an ECS task. We can then include those config files in the primary dev/prod configurations. 

**Ticket**

[NAPPS-1592 
](https://arcpublishing.atlassian.net/browse/NAPPS-1592)

**Testing steps:** 

We can use Stackjack to verify the parameters compile as valid template: 

1. To check ECS dev template:`stackjack build cfn/ecs-task/configs/dev/us-east-1/config.yml --output-file output-dev-task-config.yml`
2. To check ECS prod template: `stackjack build cfn/ecs-task/configs/prod/us-east-1/config.yml --output-file output-prod-task-config.yml`
3. To check entire dev template:`stackjack build cfn/configs/klaxon/dev/us-east-1/config.yml --output-file output-dev-config.yml`
4. To check entire prod template:`stackjack build cfn/configs/klaxon/prod/us-east-1/config.yml --output-file output-prod-config.yml`