### PR TITLE
NAPPS 1697: Removing `use cron` argument from buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,11 +23,10 @@ phases:
 
   build:
     on-failure: ABORT
-    commands: # Temporarily set USE_CRON=true while we debug ECS scheduled task
+    commands: 
       - | 
         docker build \
           --cache-from $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$APP_NAME:$DEPLOYMENT_ENV-latest \
-          --build-arg USE_CRON=true \
           -t $APP_NAME:$DEPLOYMENT_ENV-`cat commit_hash` \
           -f $DOCKERFILE_SERVER_PATH .
 


### PR DESCRIPTION
This PR removes `USE_CRON` from the buildspec.yml file to test whether or not the cron is running when deployed. 