### PR TITLE
NAPPS-1645: configuring datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'aws-sdk-sqs', '~> 1.52'
 
 gem 'rails-healthcheck'
 
+gem 'ddtrace', require: 'ddtrace/auto_instrument'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'
@@ -51,3 +53,4 @@ group :development do
   gem 'web-console', '~> 4.2'
   gem 'spring'
 end
+

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -430,6 +430,10 @@ context:
       SES_USERNAME: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:username}}"
       SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:password}}"
 
+      # Datadog env configuration
+      DD_ENV: dev
+      DD_SERVICE: klaxon-server
+
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime
 

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -432,6 +432,10 @@ context:
       MAILER_FROM_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:mailerFromAddress}}"
       SES_USERNAME: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:username}}"
       SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:password}}"
+
+      # Datadog env configuration
+      DD_ENV: prod
+      DD_SERVICE: klaxon-server
   
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,5 @@
+Datadog.configure do |c|
+    # Add additional configuration here.
+    # Activate integrations, change tracer settings, etc...
+  end
+  


### PR DESCRIPTION
This is a very rough attempt to set up datadog monitoring for the Klaxon service. 

I attempted to follow the directions outlined in the [Ruby documentation](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby#getting-started). 


There are additional integrations with Datadog tracing that we may want to look into:
- [Rake](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby#rake) — For our `rake check:all` command
- [AWS](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby#aws) — For our API calls to SES
- [Postgres](https://www.notion.so/Klaxon-DD-monitoring-c0b05d4f302246d5909f978714239661) — For our communications with the Klaxon DB 

However, I wanted to limit our concern with this initial PR to simply getting the Klaxon trace to show up on Datadog's [APM page](https://washpost.datadoghq.com/apm/home).