### PR TITLE
NAPPS-1698: adding ecr repo for klaxon rake command

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/image/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/image/us-east-1/config.yml
@@ -1,0 +1,8 @@
+# This generates an ECR repository
+# `name` here must  be the same as the `APP_NAME`-rake in the build step
+
+template: v1/cfn/shared/clusters/simple-ecs/service/image.template.yml
+stack_name: klaxon-rake-image
+region: us-east-1
+context:
+  name: klaxon-rake


### PR DESCRIPTION
Klaxon rake scheduled task successfully running once every 10 minutes. However, each task fails to start with the [following error](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/newsroom-dev/tasks/02c27541db1c4a5a89aea1d2e38a1069/configuration/containers/klaxon-dev?region=us-east-1):

```
CannotPullContainerError: Error response from daemon: repository 912288704264.dkr.ecr.us-east-1.amazonaws.com/klaxon-rake not found: name unknown: The repository with name 'klaxon-rake' does not exist in the registry with id '912288704264'
``` 

If we look on [ECR](https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1), we see that we only have the `klaxon` repo. My hunch is that we need to deploy another `image`, this one called `klaxon-rake`
