### PR TITLE
NAPPS-1698: fix logs error

### DIFF
--- a/cfn/templates/ecs-task.template.yml
+++ b/cfn/templates/ecs-task.template.yml
@@ -50,7 +50,7 @@ Resources:
           LogConfiguration:
               LogDriver: awslogs
               Options:
-                  awslogs-group: /service/klaxon-scheduled-task/dev
+                  awslogs-group: /service/klaxon/dev
                   awslogs-region: !Ref AWS::Region
                   awslogs-stream-prefix: dev
           ExtraHosts: [{'Hostname': 'statsd', 'IpAddress': '172.17.0.1'}]

--- a/cfn/templates/ecs-task.template.yml
+++ b/cfn/templates/ecs-task.template.yml
@@ -52,7 +52,7 @@ Resources:
               Options:
                   awslogs-group: /service/klaxon/dev
                   awslogs-region: !Ref AWS::Region
-                  awslogs-stream-prefix: dev
+                  awslogs-stream-prefix: rake-page-check-dev
           ExtraHosts: [{'Hostname': 'statsd', 'IpAddress': '172.17.0.1'}]
         {%- if environment is mapping %}
         {# blankline #}


### PR DESCRIPTION
Getting a logging error:
```
CannotStartContainerError: Error response from daemon: failed to initialize logging driver: failed to create Cloudwatch log stream: ResourceNotFoundException: The specified log group does not exist.
```

@aaronbrezel and I are thinking it might be best to log from the page-checking task to the same log group as the main app server, but with a different log stream prefix. This is our attempt at configuring that.