### PR TITLE
NAPPS-1645: set DD_AGENT_HOST

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
@@ -58,4 +58,5 @@ context:
 
     # Datadog env configuration
     DD_ENV: dev
-    DD_SERVICE: klaxon-server
+    DD_SERVICE: klaxon-rake
+    DD_AGENT_HOST: 172.17.0.1

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -430,6 +430,7 @@ context:
       # Datadog env configuration
       DD_ENV: dev
       DD_SERVICE: klaxon-server
+      DD_AGENT_HOST: 172.17.0.1
 
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -431,9 +431,10 @@ context:
       SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:password}}"
 
       # Datadog env configuration
-      DD_ENV: prod
+      DD_ENV: dev
       DD_SERVICE: klaxon-server
-  
+      DD_AGENT_HOST: 172.17.0.1
+      
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime
 

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -431,10 +431,10 @@ context:
       SES_PASSWORD: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:password}}"
 
       # Datadog env configuration
-      DD_ENV: dev
+      DD_ENV: prod
       DD_SERVICE: klaxon-server
       DD_AGENT_HOST: 172.17.0.1
-      
+
     # environment: dictionary
     #   This allows environment values to be passed to the execution of the container at runtime
 


### PR DESCRIPTION
In talking with the Datadog rep, it seems like we need to add the `DD_AGENT_HOST` in order to get the datadog tracer to connect with the agent running on the ec2 host. 