### PR TITLE
NAPPS-1760: templatizing ecs task template by environment

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
@@ -39,6 +39,13 @@ context:
   container_name: klaxon-dev
   image: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon-rake:dev-latest
   schedule_expression: "0/10 * * * ? *"
+  klaxon_events_rule: klaxon-events-rule-dev
+  awslogs_group: /service/klaxon/dev
+  awslogs_stream_prefix: rake-page-check-dev
+  task_execution_role: klaxon-page-check-task-execution-role-dev
+  cluster_arn: arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/newsroom-dev
+  cluster_id: newsroom-dev
+  event_execution_role: klaxon-scheduled-event-execution-role-dev
   environment:
     DATABASE_URL: "{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:database-url}}"
     ADMIN_EMAILS: "admin@news.org"

--- a/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
@@ -39,6 +39,13 @@ context:
   container_name: klaxon-prod
   image: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon-rake:prod-latest
   schedule_expression: "0/10 * * * ? *"
+  klaxon_events_rule: klaxon-events-rule-prod
+  awslogs_group: /service/klaxon/prod
+  awslogs_stream_prefix: rake-page-check-prod
+  task_execution_role: klaxon-page-check-task-execution-role-prod
+  cluster_arn: arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/newsroom-prod
+  cluster_id: newsroom-prod
+  event_execution_role: klaxon-scheduled-event-execution-role-prod
   environment:
     DATABASE_URL: "{{resolve:secretsmanager:/klaxon/aurora-postgresql-prod/app:SecretString:database-url}}"
     ADMIN_EMAILS: "admin@news.org"

--- a/cfn/templates/ecs-task.template.yml
+++ b/cfn/templates/ecs-task.template.yml
@@ -32,9 +32,9 @@ Resources:
           LogConfiguration:
               LogDriver: awslogs
               Options:
-                  awslogs-group: /service/klaxon/dev
+                  awslogs-group: {{ awslogs_group }}
                   awslogs-region: !Ref AWS::Region
-                  awslogs-stream-prefix: rake-page-check-dev
+                  awslogs-stream-prefix: {{ awslogs_stream_prefix }}
           ExtraHosts: [{'Hostname': 'statsd', 'IpAddress': '172.17.0.1'}]
         # This jinja block covers mapping over environment vars from config
         # copied in from v1/cfn/shared/apps/ecs-v2/service.template.yml stackjack template
@@ -117,7 +117,7 @@ Resources:
                 - ecs-tasks.amazonaws.com
                 - events.amazonaws.com
       Policies:
-      - PolicyName: klaxon-page-check-task-execution-role            
+      - PolicyName: {{ task_execution_role }}            
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -138,12 +138,12 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: Klaxon ecs task scheduler
-      Name: klaxon-ecs-task-scheduler
+      Name: {{ klaxon_events_rule }}
       ScheduleExpression: cron({{ schedule_expression }})
       State: ENABLED
       Targets:
-        - Arn: !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/newsroom-dev" # cluster arn, hardcoding for now
-          Id: klaxon-page-check-ecs-task
+        - Arn: !Sub {{ cluster_arn }}
+          Id: {{ cluster_id }}
           RoleArn: !GetAtt EC2ServiceEventsExecutionRole.Arn #ecs events role
           EcsParameters:
             TaskCount: 1
@@ -154,7 +154,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: A role for event to execute Klaxon ECS task
-      RoleName: {{ family }}
+      RoleName: {{ event_execution_role }}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
Our prod deployment broke terribly because of duplicate resource names — that is, the prod resources can't have the same name as the already-deployed dev resources. This is my first CFN template rodeo, and I just didn't foresee that being as big of an issue as it was.

Please let me know if you see anything else that should be renamed/templatized. I am going with more verbose configs with longer, more descriptive, key names for clarity. 

Both prod and dev templates are building correctly:

```
stackjack build cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml --output-file dev.yml
```
```
stackjack build cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml --output-file prod.yml
```

and they are validating:
```
cfn-lint dev.yml
```
```
cfn-lint prod.yml
```