### PR TITLE
hotfix: adding DD_AGENT_HOST to prod rake task

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
@@ -67,3 +67,4 @@ context:
     # Datadog env configuration
     DD_ENV: prod
     DD_SERVICE: klaxon-server
+    DD_AGENT_HOST: 172.17.0.1


### PR DESCRIPTION
A quick update to include a missing variable in the prod klaxon rake scheduled task. 