### PR TITLE
Hotfix: datadog klaxon-rake service

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
@@ -66,5 +66,5 @@ context:
 
     # Datadog env configuration
     DD_ENV: prod
-    DD_SERVICE: klaxon-server
+    DD_SERVICE: klaxon-rake
     DD_AGENT_HOST: 172.17.0.1


### PR DESCRIPTION
fixing an issue where the prod klaxon scheduled task config was pointing datadog towards a "klaxon-server" service. It should read "klaxon-rake", matching what's in the dev scheduled task config. 