### PR TITLE
Fix/WP logo not displaying on dev

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,8 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# Uncomment the lines below if logo SVG does not compile when deployed
-# Rails.application.config.assets.precompile += %w( '.svg' )  
-# Rails.application.config.assets.css_compressor = :sass
+# Precompiles SVG so that org logo will display in deployed app
+Rails.application.config.assets.precompile += %w( '.svg' )  
+Rails.application.config.assets.css_compressor = :sass
 
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'


### PR DESCRIPTION
## Description

Looks like we do indeed need to add something to `config/initializers/assets.rb` that precompiles the SVG assets. Hoping this will do the trick to get the logo displaying on dev.

## Testing steps

- deploy and see if logo appears