### PR TITLE
Futzing css compiling

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
@@ -55,7 +55,7 @@ context:
     RAILS_ENV: production
     HOST_URL: "sandbox.washpost.arcpublishing.com"
     SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
-    KLAXON_COMPILE_ASSETS: true
+    KLAXON_COMPILE_ASSETS: false
     SMTP_PROVIDER: SES
     SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:address}}"
     SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:domain}}"

--- a/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
@@ -55,7 +55,7 @@ context:
     RAILS_ENV: production
     HOST_URL: "washpost.arcpublishing.com"
     SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
-    KLAXON_COMPILE_ASSETS: true
+    KLAXON_COMPILE_ASSETS: false
     SMTP_PROVIDER: SES
     SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:address}}"
     SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:domain}}"

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -418,7 +418,7 @@ context:
       RAILS_ENV: production
       HOST_URL: "sandbox.washpost.arcpublishing.com"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
-      KLAXON_COMPILE_ASSETS: true
+      KLAXON_COMPILE_ASSETS: false
       SMTP_PROVIDER: SES
       SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:address}}"
       SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:domain}}"

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -421,7 +421,7 @@ context:
       RAILS_ENV: production
       HOST_URL: "washpost.arcpublishing.com"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
-      KLAXON_COMPILE_ASSETS: true
+      KLAXON_COMPILE_ASSETS: false
       SMTP_PROVIDER: SES
       SES_ADDRESS: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:address}}"
       SES_DOMAIN: "{{resolve:secretsmanager:/klaxon/ses-prod/smtp-user-credentials:SecretString:domain}}"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,9 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Precompiles SVG so that org logo will display in deployed app
-Rails.application.config.assets.precompile += %w( '.svg' )  
-Rails.application.config.assets.css_compressor = :sass
-
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
@@ -12,4 +8,8 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( search.js )
+# addition of '.svg' allows custom logo to display
+Rails.application.config.assets.precompile += %w( search.js '.svg')
+
+# css_compressor needed for svg to display according to: https://stackoverflow.com/a/36992492
+Rails.application.config.assets.css_compressor = :sass


### PR DESCRIPTION
This is non-urgent, but I'm trying to sort out why assets are not getting re-compiled on deploy the way I would expect. Note that, despite a release this week, [prod](https://klaxon-prod.news-engineering.aws.wapo.pub/klaxon/login?return_to=https%3A%2F%2Fklaxon-prod.news-engineering.aws.wapo.pub%2Fklaxon) does not have the WP logo at the top left the way [dev](https://klaxon-dev.news-engineering.aws.wapo.pub/klaxon/login?return_to=https%3A%2F%2Fklaxon-dev.news-engineering.aws.wapo.pub%2Fklaxon) does. (Getting dev to work was a matter of waiting a week, so I suspect some fishy asset caching business that doesn't get resolved by clearing my browser cache.)

I don't think this will be a fix, but in trying to read more about Rails asset compilation, I realized we are using the wrong `config.assets.compile` setting for our deployed apps. We are both pre-compiling and have compiling set to `true` per request for relevant assets. I am not sure what the impact is of that (maybe nothing), but we should at least correct this, since it might be contributing to higher latency in the app.