### PR TITLE
NAPPS-2238: add logging user actions

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -60,7 +60,7 @@ class PagesController < ApplicationController
   # PATCH/PUT /pages/1
   def update
     if @page.update(page_params)
-      now = Time.now
+      now = Time.zone.now
       Rails.logger.info "#{now} user with email #{current_user.email} and ID #{current_user.id} has updated a page called \"#{@page.name}\" with ID #{@page.id}."
       redirect_to pages_url, notice: 'Page was successfully updated.'
     else
@@ -70,7 +70,7 @@ class PagesController < ApplicationController
 
   # DELETE /pages/1
   def destroy
-    now = Time.now
+    now = Time.zone.now
     Rails.logger.info "#{now} user, email #{current_user.email} and ID #{current_user.id}, deleted a page called \"#{@page.name}\" with ID #{@page.id}."
     @page.destroy
     redirect_to pages_url, notice: 'Page was successfully destroyed.'

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -51,7 +51,7 @@ class PagesController < ApplicationController
 
     if @page.save
       redirect_to pages_url, notice: 'Page was successfully created.'
-      Rails.logger.info "#{@page.created_at} User, email #{current_user.email} and id #{current_user.id}, created a page called #{@page.name} with id #{@page.id}."
+      Rails.logger.info "#{@page.created_at} User, email #{current_user.email} and ID #{current_user.id}, created a page \"#{@page.name}\" with ID #{@page.id}."
     else
       render :new
     end
@@ -60,6 +60,8 @@ class PagesController < ApplicationController
   # PATCH/PUT /pages/1
   def update
     if @page.update(page_params)
+      now = Time.now
+      Rails.logger.info "#{now} User with email #{current_user.email} and ID #{current_user.id} has updated a page called #{@page.name} with ID #{@page.id}:\n#{page_params}"
       redirect_to pages_url, notice: 'Page was successfully updated.'
     else
       render :edit
@@ -68,8 +70,8 @@ class PagesController < ApplicationController
 
   # DELETE /pages/1
   def destroy
-    now = Time.now.to_i
-    Rails.logger.info "#{now} User, email #{current_user.email} and id #{current_user.id}, deleted a page called #{@page.name} with id #{@page.id}."
+    now = Time.now
+    Rails.logger.info "#{now} User, email #{current_user.email} and ID #{current_user.id}, deleted a page called #{@page.name} with ID #{@page.id}."
     @page.destroy
     redirect_to pages_url, notice: 'Page was successfully destroyed.'
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -68,6 +68,8 @@ class PagesController < ApplicationController
 
   # DELETE /pages/1
   def destroy
+    now = Time.now.to_i
+    Rails.logger.info "#{now} User, email #{current_user.email} and id #{current_user.id}, deleted a page called #{@page.name} with id #{@page.id}."
     @page.destroy
     redirect_to pages_url, notice: 'Page was successfully destroyed.'
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -51,7 +51,7 @@ class PagesController < ApplicationController
 
     if @page.save
       redirect_to pages_url, notice: 'Page was successfully created.'
-      Rails.logger.info "#{@page.created_at} User, email #{current_user.email} and ID #{current_user.id}, created a page \"#{@page.name}\" with ID #{@page.id}."
+      Rails.logger.info "#{@page.created_at} user, email #{current_user.email} and ID #{current_user.id}, created a page \"#{@page.name}\" with ID #{@page.id}."
     else
       render :new
     end
@@ -61,7 +61,7 @@ class PagesController < ApplicationController
   def update
     if @page.update(page_params)
       now = Time.now
-      Rails.logger.info "#{now} User with email #{current_user.email} and ID #{current_user.id} has updated a page called #{@page.name} with ID #{@page.id}:\n#{page_params}"
+      Rails.logger.info "#{now} user with email #{current_user.email} and ID #{current_user.id} has updated a page called \"#{@page.name}\" with ID #{@page.id}."
       redirect_to pages_url, notice: 'Page was successfully updated.'
     else
       render :edit
@@ -71,7 +71,7 @@ class PagesController < ApplicationController
   # DELETE /pages/1
   def destroy
     now = Time.now
-    Rails.logger.info "#{now} User, email #{current_user.email} and ID #{current_user.id}, deleted a page called #{@page.name} with ID #{@page.id}."
+    Rails.logger.info "#{now} user, email #{current_user.email} and ID #{current_user.id}, deleted a page called \"#{@page.name}\" with ID #{@page.id}."
     @page.destroy
     redirect_to pages_url, notice: 'Page was successfully destroyed.'
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -51,6 +51,7 @@ class PagesController < ApplicationController
 
     if @page.save
       redirect_to pages_url, notice: 'Page was successfully created.'
+      Rails.logger.info "#{@page.created_at} User, email #{current_user.email} and id #{current_user.id}, created a page called #{@page.name} with id #{@page.id}."
     else
       render :new
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
       redirect_to unknown_user_path and return false
     end
 
-    now = Time.now
+    now = Time.zone.now
     Rails.logger.info "#{now} login email requested for #{params[:session][:email].downcase}"
     UserMailer.login_email(user: user).deliver_later
     # Allow the login page to display in the bookmarklet iframe
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
       if user[:expired]
         redirect_to expired_token_path(user[:user].id)
       else
-        now = Time.now
+        now = Time.zone.now
         Rails.logger.info "#{now} user with email #{user.email} and ID #{user.id} has successfully authenticated."
         cookies.signed[:user_id] = { value: user.id, expires: 7.days.from_now, httponly: true, same_site: :none, secure: true }
         redirect_to root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,6 +10,8 @@ class SessionsController < ApplicationController
       redirect_to unknown_user_path and return false
     end
 
+    now = Time.now
+    Rails.logger.info "#{now} login email requested for #{params[:session][:email].downcase}"
     UserMailer.login_email(user: user).deliver_later
     # Allow the login page to display in the bookmarklet iframe
     response.headers.delete "X-Frame-Options"
@@ -21,6 +23,8 @@ class SessionsController < ApplicationController
       if user[:expired]
         redirect_to expired_token_path(user[:user].id)
       else
+        now = Time.now
+        Rails.logger.info "#{now} user with email #{user.email} and ID #{user.id} has successfully authenticated."
         cookies.signed[:user_id] = { value: user.id, expires: 7.days.from_now, httponly: true, same_site: :none, secure: true }
         redirect_to root_path
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,7 @@ class UsersController < ApplicationController
     if @user.save
       UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
 
+      Rails.logger.info "#{@user.created_at} User, email #{current_user.email} and id #{current_user.id}, created another user with email #{@user.email} with id #{@user.id}."
       redirect_to users_url, notice: 'User was successfully created.'
     else
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,6 +58,8 @@ class UsersController < ApplicationController
       return false
     end
 
+    now = Time.now.to_i
+    Rails.logger.info "#{now} User, email #{current_user.email} and id #{current_user.id}, deleted a user with email #{@user.email} and id #{@user.id}."
     @user.subscriptions.destroy_all
     @user.destroy
     redirect_to users_url, notice: 'User was successfully deleted.'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
     if @user.save
       UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
 
-      Rails.logger.info "#{@user.created_at} User, email #{current_user.email} and ID #{current_user.id}, created another user with email #{@user.email} with ID #{@user.id}."
+      Rails.logger.info "#{@user.created_at} user, email #{current_user.email} and ID #{current_user.id}, created another user with email #{@user.email} with ID #{@user.id}."
       redirect_to users_url, notice: 'User was successfully created.'
     else
       render :new
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
 
     if @user.update(user_params)
       now = Time.now
-      Rails.logger.info "#{now} User with email #{current_user.email} and ID #{current_user.id} has updated a user with email #{@user.email} with ID #{@user.id}:\n#{user_params}"
+      Rails.logger.info "#{now} user with email #{current_user.email} and ID #{current_user.id} has updated a user with email #{@user.email} with ID #{@user.id}."
       redirect_to users_url, notice: 'User was successfully updated.'
     else
       render :edit
@@ -61,7 +61,7 @@ class UsersController < ApplicationController
     end
 
     now = Time.now
-    Rails.logger.info "#{now} User, email #{current_user.email} and ID #{current_user.id}, deleted a user with email #{@user.email} and ID #{@user.id}."
+    Rails.logger.info "#{now} user, email #{current_user.email} and ID #{current_user.id}, deleted a user with email #{@user.email} and ID #{@user.id}."
     @user.subscriptions.destroy_all
     @user.destroy
     redirect_to users_url, notice: 'User was successfully deleted.'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
     if @user.save
       UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
 
-      Rails.logger.info "#{@user.created_at} User, email #{current_user.email} and id #{current_user.id}, created another user with email #{@user.email} with id #{@user.id}."
+      Rails.logger.info "#{@user.created_at} User, email #{current_user.email} and ID #{current_user.id}, created another user with email #{@user.email} with ID #{@user.id}."
       redirect_to users_url, notice: 'User was successfully created.'
     else
       render :new
@@ -45,6 +45,8 @@ class UsersController < ApplicationController
     end
 
     if @user.update(user_params)
+      now = Time.now
+      Rails.logger.info "#{now} User with email #{current_user.email} and ID #{current_user.id} has updated a user with email #{@user.email} with ID #{@user.id}:\n#{user_params}"
       redirect_to users_url, notice: 'User was successfully updated.'
     else
       render :edit
@@ -58,8 +60,8 @@ class UsersController < ApplicationController
       return false
     end
 
-    now = Time.now.to_i
-    Rails.logger.info "#{now} User, email #{current_user.email} and id #{current_user.id}, deleted a user with email #{@user.email} and id #{@user.id}."
+    now = Time.now
+    Rails.logger.info "#{now} User, email #{current_user.email} and ID #{current_user.id}, deleted a user with email #{@user.email} and ID #{@user.id}."
     @user.subscriptions.destroy_all
     @user.destroy
     redirect_to users_url, notice: 'User was successfully deleted.'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,7 +45,7 @@ class UsersController < ApplicationController
     end
 
     if @user.update(user_params)
-      now = Time.now
+      now = Time.zone.now
       Rails.logger.info "#{now} user with email #{current_user.email} and ID #{current_user.id} has updated a user with email #{@user.email} with ID #{@user.id}."
       redirect_to users_url, notice: 'User was successfully updated.'
     else
@@ -60,7 +60,7 @@ class UsersController < ApplicationController
       return false
     end
 
-    now = Time.now
+    now = Time.zone.now
     Rails.logger.info "#{now} user, email #{current_user.email} and ID #{current_user.id}, deleted a user with email #{@user.email} and ID #{@user.id}."
     @user.subscriptions.destroy_all
     @user.destroy


### PR DESCRIPTION
[NAPPS-2238]

Adds logging for important user actions. Note that, contrary to the way I wrote the ticket, the logs don't actually detail the changes made to a user or page record. Instead, record update events will log the timestamp, user who performed the action, and the affected record.

## Testing

Perform the actions listed in [this debugging guide](https://paper.dropbox.com/doc/Debugging-guide--B~h6hp4qqlxJHkYbUpuqdcEGAg-gbEaNp1Fua6omakibdm3b) and search your terminal for the correct logs.

(Note: the local logs are kind of haywire. I'd recommend a Command + F search, rather than eye-scanning)

[NAPPS-2238]: https://arcpublishing.atlassian.net/browse/NAPPS-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ