### PR TITLE
NAPPS-2239: remove trident url from emails

### DIFF
--- a/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/dev/us-east-1/config.yml
@@ -53,7 +53,7 @@ context:
     APP_HOST: klaxon-dev.news-engineering.aws.wapo.pub.
     RACK_ENV: production
     RAILS_ENV: production
-    HOST_URL: "sandbox.washpost.arcpublishing.com"
+    HOST_URL: "klaxon-dev.news-engineering.aws.wapo.pub"
     SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
     KLAXON_COMPILE_ASSETS: false
     SMTP_PROVIDER: SES

--- a/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon-scheduled-task/prod/us-east-1/config.yml
@@ -53,7 +53,7 @@ context:
     APP_HOST: klaxon-prod.news-engineering.aws.wapo.pub.
     RACK_ENV: production
     RAILS_ENV: production
-    HOST_URL: "washpost.arcpublishing.com"
+    HOST_URL: "klaxon-prod.news-engineering.aws.wapo.pub"
     SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
     KLAXON_COMPILE_ASSETS: false
     SMTP_PROVIDER: SES

--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -416,7 +416,7 @@ context:
       APP_HOST: klaxon-dev.news-engineering.aws.wapo.pub.
       RACK_ENV: production
       RAILS_ENV: production
-      HOST_URL: "sandbox.washpost.arcpublishing.com"
+      HOST_URL: "klaxon-dev.news-engineering.aws.wapo.pub"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: false
       SMTP_PROVIDER: SES

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -419,7 +419,7 @@ context:
       APP_HOST: klaxon-prod.news-engineering.aws.wapo.pub.
       RACK_ENV: production
       RAILS_ENV: production
-      HOST_URL: "washpost.arcpublishing.com"
+      HOST_URL: "klaxon-prod.news-engineering.aws.wapo.pub"
       SECRET_KEY_BASE: "{{resolve:secretsmanager:/klaxon/prod/secret-key:SecretString:secret_key_base}}"
       KLAXON_COMPILE_ASSETS: false
       SMTP_PROVIDER: SES


### PR DESCRIPTION
## Description
Now that we aren't using Trident to prettify our URL (in order to get the bookmarklet working again), we don't want the URL used in the emails to be the Trident URL. This returns us to using the ".pub" URLs.

## Ticket
[NAPPS-2239]

## Testing
- confirm the links are correct

[NAPPS-2239]: https://arcpublishing.atlassian.net/browse/NAPPS-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ