### PR TITLE
NAPPS-2239: fixing logger

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,10 +55,10 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [ :subdomain, :uuid ]
 
   # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Uncommenting lines in `production.rb` in an attempt to get logs that are working locally to appear in the ECS console.