### PR TITLE
NAPPS-2239: adding comment to the fix that worked for deployed logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  
+  # Logs work locally but won't appear in the ECS console or CloudWatch without this:
   config.logger = Logger.new(STDOUT)
 
   # Use a different cache store in production.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,10 +55,10 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [ :subdomain, :uuid ]
 
   # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,10 +55,11 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :subdomain, :uuid ]
+  # config.log_tags = [ :subdomain, :uuid ]
 
   # Use a different logger for distributed setups.
-  config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = Logger.new(STDOUT)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
To recap, logs were working locally, but not appearing in [the ECS console](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/newsroom-dev/services/newsroom-dev-klaxon-Service-ueC7ipc3Gq0j/logs?region=us-east-1).

So, I [tried uncommenting some lines](https://github.com/WPMedia/klaxon/pull/105) in `production.rb` related to logging. Sadly, that did not work.

Per [this blog post](https://blog.shikisoft.com/rails-logging-for-docker-amazon-ecs-fargate/), I tried modifying the `config.logger` value to be `Logger.new(STDOUT)`, and now it seems we have success! So, this change is just adding a comment to explain that line.