### PR TITLE
NAPPS-2409: fix image path reference

### DIFF
--- a/cfn/configs/klaxon/dev/us-east-1/config.yml
+++ b/cfn/configs/klaxon/dev/us-east-1/config.yml
@@ -407,7 +407,7 @@ context:
     # image = provider/project/repo:tag
     #         In order for "image" to be reconized as raw_image_path, it must contain a "/" or a ":"
     #
-    raw_image_path: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:dev-latest
+    raw_image_path: !_join [":", "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon", "dev-{{resolve:ssm:/deployments/klaxon-dev/latest}}"]
 
     environment:
       DATABASE_URL: "{{resolve:secretsmanager:/klaxon/aurora-postgresql-dev/app:SecretString:database-url}}"

--- a/cfn/configs/klaxon/prod/us-east-1/config.yml
+++ b/cfn/configs/klaxon/prod/us-east-1/config.yml
@@ -409,7 +409,7 @@ context:
     # image = provider/project/repo:tag
     #         In order for "image" to be reconized as raw_image_path, it must contain a "/" or a ":"
     #
-    raw_image_path: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon:prod-latest
+    raw_image_path: !_join [":", "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/klaxon", "prod-{{resolve:ssm:/deployments/klaxon-prod/latest}}"]
 
 
     environment:


### PR DESCRIPTION
Rather than referring to images by the `latest` tag, we're going to start retrieving the most recent image hash and using that as the image path. This will hopefully address the issue of tasks not "realizing" they need to redeploy for some changes.

Will need to merge to test.