### PR TITLE
NAPPS-2465: updating packages in dockerfile for wiz fix

### DIFF
--- a/Dockerfile.rake
+++ b/Dockerfile.rake
@@ -3,6 +3,9 @@ FROM public.ecr.aws/docker/library/ruby:2.7.7
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
+# Updating packages
+RUN apt update && apt upgrade -yqq
+
 # Set up the app directory
 WORKDIR /usr/src/app
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -3,8 +3,8 @@ FROM public.ecr.aws/docker/library/ruby:2.7.7
 ARG USE_CRON=false
 ENV USE_CRON=${USE_CRON}
 
-# Install cron
-RUN apt-get -y update && apt-get install -y cron
+# Update packages and install cron
+RUN apt -y update && apt upgrade -yqq && apt install -y cron
 # Create the log file to be able to store logs
 RUN touch /var/log/cron.log
 # Cron (at least in Debian) does not execute crontabs with more than 1 hardlink, see bug 647193.


### PR DESCRIPTION
Rather than the fixes prescribed in the ticket, which call for updating packages that aren't installed, the team has moved to instead update all installed packages [like so](https://github.com/WPMedia/capitol-arrests-admin/pull/113).

To test:
`docker-compose down`
`docker-compose build`
`docker-compose up`
Confirm the app loads at localhost:3001/klaxon